### PR TITLE
Add out of repo code reference tags

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -14,6 +14,7 @@ namespace b2c_ms_graph
     {
         static async Task Main(string[] args)
         {
+            //<ms_docref_set_auth_provider>
             // Read application settings from appsettings.json (tenant ID, app ID, client secret, etc.)
             AppSettings config = AppSettingsFile.ReadFromJsonFile();
 
@@ -21,7 +22,7 @@ namespace b2c_ms_graph
             var scopes = new[] { "https://graph.microsoft.com/.default" };
             var clientSecretCredential = new ClientSecretCredential(config.TenantId, config.AppId, config.ClientSecret);
             var graphClient = new GraphServiceClient(clientSecretCredential, scopes);
-
+            //</ms_docref_set_auth_provider>
             PrintCommands();
 
             try

--- a/src/Services/UserService.cs
+++ b/src/Services/UserService.cs
@@ -12,6 +12,8 @@ namespace b2c_ms_graph
 {
     class UserService
     {
+        
+        //<ms_docref_get_list_of_user_accounts>
         public static async Task ListUsers(GraphServiceClient graphClient)
         {
             Console.WriteLine("Getting list of users...");
@@ -57,7 +59,7 @@ namespace b2c_ms_graph
                 Console.ResetColor();
             }
         }
-
+        //</ms_docref_get_list_of_user_accounts>
 
         public static async Task CountUsers(GraphServiceClient graphClient)
         {


### PR DESCRIPTION
In this PR:
- Add `ms_docref_set_auth_provider` out of repo code reference tag in `Program.cs` file
- Add `ms_docref_get_list_of_user_accounts` out of repo code reference tag in `UserService.cs` file

These tags need to be used to update code in [Manage Azure AD B2C with Microsoft Graph](https://docs.microsoft.com/en-us/azure/active-directory-b2c/microsoft-graph-operations#code-discussion). Code snippets used were updated in the repo but not in the doc. 